### PR TITLE
Copy only pixel data per row, skip pitch padding

### DIFF
--- a/RetroGBm/Source/Render/RenderTexture.cpp
+++ b/RetroGBm/Source/Render/RenderTexture.cpp
@@ -103,10 +103,12 @@ void Render::RenderTexture::Update(void* video_buffer, int video_pitch)
 	uint8_t* src = static_cast<uint8_t*>(video_buffer);
 	uint8_t* dst = static_cast<uint8_t*>(resource.pData);
 
+	const size_t row_bytes = static_cast<size_t>(m_Width) * sizeof(uint32_t);
+
 	// Update the texture
 	for (int row = 0; row < m_Height; ++row)
 	{
-		std::memcpy(dst, src, resource.RowPitch);
+		std::memcpy(dst, src, row_bytes);
 		src += video_pitch;
 		dst += resource.RowPitch;
 	}


### PR DESCRIPTION
The code now calculates row_bytes as width × 32-bit pixel size. It copies only row_bytes per row, avoiding extra pitch padding that may be present in resource.RowPitch. This ensures only actual pixel data is copied, preventing buffer overrun or unintended memory access.